### PR TITLE
鎖定依賴版本 + 重寫 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,80 @@
-# MooSaver
+<div align="center">
 
-一個基於 Django 的 Moodle 資源下載工具，幫助用戶輕鬆下載和管理 Moodle 平台上的課程資源。
+# 🐄 MooSaver
 
-## 功能特色
+**一鍵批次備份 Moodle 課程資源的自架下載工具**
 
-- 🚀 **快速下載**：一鍵批量下載所有課程資源
-- 📁 **智能整理**：自動按課程分類，檔案管理更清晰
-- 🔍 **檔案搜尋**：快速搜尋和定位檔案
-- 👥 **多用戶支援**：支援多個使用者獨立管理資源
-- 🎨 **響應式設計**：支援桌面和行動裝置
+*Batch-download and organise all your Moodle course files from a single self-hosted web app.*
 
-## 技術架構
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
+[![Django](https://img.shields.io/badge/Django-6.0-092E20?logo=django&logoColor=white)](https://www.djangoproject.com/)
+[![Vue.js](https://img.shields.io/badge/Vue.js-3-4FC08D?logo=vuedotjs&logoColor=white)](https://vuejs.org/)
+[![Docker](https://img.shields.io/badge/Docker-ready-2496ED?logo=docker&logoColor=white)](https://hub.docker.com/r/0blueyan0/moosaver)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#-貢獻)
 
-- **後端**：Django 5.x
-- **前端**：Vue.js
+</div>
 
-## 安裝與部署
+---
+
+MooSaver 是一個基於 **Django + Vue.js** 的 Moodle 資源下載工具。輸入學號與密碼後，它會透過 Moodle 官方 Mobile App API 取得存取權杖，批次抓取你所有課程的講義、作業、公告等資源，並自動按課程分類、集中管理，讓你不必再一個一個檔案手動點下載。
+
+> 底層下載引擎採用開源專案 [Moodle-DL](https://github.com/C0D3D3V/Moodle-DL)，並包裝成友善的多使用者 Web 介面。
+
+## 📖 目錄
+
+- [功能特色](#-功能特色)
+- [支援平台](#-支援平台)
+- [技術架構](#-技術架構)
+- [快速開始](#-快速開始)
+  - [使用 Docker（推薦）](#使用-docker推薦)
+  - [本地開發](#本地開發)
+- [設定說明](#-設定說明)
+- [使用方法](#-使用方法)
+- [專案結構](#-專案結構)
+- [安全性說明](#-安全性說明)
+- [Roadmap](#-roadmap)
+- [貢獻](#-貢獻)
+- [開源致謝](#-開源致謝)
+- [授權條款](#-授權條款)
+
+## ✨ 功能特色
+
+- 🚀 **一鍵批次下載** — 自動抓取所有課程的資源，不需逐一手動點擊
+- 📁 **智能整理** — 依課程自動分類建立資料夾，檔案結構清晰
+- 🗂️ **線上檔案管理** — 內建檔案樹瀏覽器，可預覽、單檔下載或整包打包成 ZIP
+- 🔍 **檔案搜尋** — 快速搜尋與定位下載後的檔案
+- 👥 **多使用者支援** — 每位使用者的資源獨立隔離、獨立管理
+- 📊 **下載統計** — 記錄下載次數與總容量，管理員可檢視全站統計
+- 🎨 **響應式介面** — 桌面與行動裝置皆適用
+
+## 🌐 支援平台
+
+| 平台 | 網址 | 狀態 |
+|------|------|------|
+| 逢甲大學 iLearn | `https://ilearn.fcu.edu.tw/` | ✅ 內建 |
+| 其他 Moodle 站台 | 自訂網址 | ✅ 支援（於下載頁選擇「自訂網址」） |
+
+> 理論上支援任何開啟了 `moodle_mobile_app` Web Service 的 Moodle 站台。
+
+## 🛠 技術架構
+
+| 層級 | 技術 |
+|------|------|
+| 後端 | Django 6.0 · Python 3.12+ |
+| 前端 | Vue.js 3（CDN 引入）· Font Awesome · Noto Sans TC |
+| 資料庫 | SQLite |
+| 下載核心 | [Moodle-DL](https://github.com/C0D3D3V/Moodle-DL) 2.3.13 |
+| 部署 | Docker / Docker Compose |
+
+## 🚀 快速開始
 
 ### 使用 Docker（推薦）
 
-#### 快速啟動
+> ⚠️ 官方 Image `0blueyan0/moosaver:latest` **僅提供 x86（amd64）平台**。若使用 Apple Silicon 或 ARM 主機，請改用[本地開發](#本地開發)方式，或自行 `docker build`。
 
-```bash
-docker run -p 8000:8000 -v /path/to/your/downloads:/app/users_data -e DATABASE_PATH=/app/users_data/db.sqlite3 0blueyan0/moosaver:latest
-```
+**快速啟動：**
 
-#### 詳細設定
-
-1. **建立資料目錄**
-```bash
-mkdir downloads
-```
-
-2. **執行容器並掛載資料卷**
 ```bash
 docker run -d \
   --name moosaver \
@@ -42,23 +84,11 @@ docker run -d \
   0blueyan0/moosaver:latest
 ```
 
-3. **開啟瀏覽器訪問**
-```
-http://localhost:8000
-```
+啟動後開啟瀏覽器造訪 <http://localhost:8000> 即可。
 
-#### 環境變數說明
+**使用 Docker Compose：**
 
-| 參數 | 說明 | 範例 |
-|------|------|------|
-| `-p 8000:8000` | 埠號對應 (主機:容器) | 可改為其他埠號如 `-p 3000:8000` |
-| `-v /path/to/your/downloads:/app/users_data` | 資料卷掛載 | 將下載檔案儲存到主機 |
-| `-e DATABASE_PATH=/app/users_data/db.sqlite3` | database路徑 | 不知道怎麼改的請保持原樣 |
-
-#### Docker Compose（推薦）
-
-- Image 僅限 x86 平台 
-- 建立 `docker-compose.yml` 檔案：
+建立 `docker-compose.yml`：
 
 ```yaml
 services:
@@ -74,88 +104,142 @@ services:
 ```
 
 執行：
+
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
+
+> 容器首次啟動時會自動執行資料庫遷移，並建立預設管理員帳號（見[使用方法](#-使用方法)）。
 
 ### 本地開發
 
-1. 安裝依賴
-- 可以使用 python 虛擬環境
+需要 **Python 3.12+**。
+
 ```bash
+# 1. 取得原始碼
+git clone https://github.com/Ruxiu0409/moosaver.git
+cd moosaver
+
+# 2. 建立並啟用虛擬環境（建議）
+python3 -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+
+# 3. 安裝依賴
 pip install -r requirements.txt
-```
 
-2. 執行資料庫遷移
-- 會建立 db.sqlite3 在 Repo 根目錄
-```bash
+# 4. 執行資料庫遷移（會在 repo 根目錄建立 db.sqlite3）
 python manage.py migrate
-```
 
-3. 建立超級使用者
-```bash
+# 5. 建立管理員帳號
 python manage.py createsuperuser
-```
 
-4. 啟動開發伺服器
-```bash
+# 6. 啟動開發伺服器
 python manage.py runserver
 ```
 
-## 使用方法
+啟動後造訪 <http://127.0.0.1:8000>。
 
-1. 註冊帳號或使用管理員帳號登入  
-   **預設管理員帳號：**  
-   帳號：`admin`  
-   密碼：`admin123`
-2. 在下載頁面輸入您的 Moodle 學號和密碼
-3. 選擇 Moodle 平台網址
-4. 點擊「開始下載」
-5. 在檔案管理頁面查看和管理下載的資源
+## ⚙️ 設定說明
 
-## 專案結構
+### Docker 環境變數
+
+| 參數 | 說明 | 範例 |
+|------|------|------|
+| `-p 8000:8000` | 埠號對應（主機:容器），可改為 `-p 3000:8000` | 主機以 3000 埠存取 |
+| `-v .../downloads:/app/users_data` | 資料卷掛載，下載檔案會存到主機此路徑 | 保留下載成果 |
+| `-e DATABASE_PATH=/app/users_data/db.sqlite3` | 資料庫檔案路徑 | 不清楚用途請保持原樣 |
+
+### 下載內容選項
+
+每次下載會依課程建立設定，預設抓取以下項目（可於 `download/views.py` 調整）：
+
+| 選項 | 預設 | 選項 | 預設 |
+|------|:---:|------|:---:|
+| 作業繳交 (submissions) | ✅ | 測驗 (quizzes) | ✅ |
+| 說明文字 (descriptions) | ✅ | 工作坊 (workshops) | ✅ |
+| 討論區 (forums) | ✅ | 資料庫 (databases) | ❌ |
+| 課程 (lessons) | ❌ | 書本 (books) | ❌ |
+| 行事曆 (calendars) | ❌ | 說明中的連結檔案 | ❌ |
+
+## 📚 使用方法
+
+1. **登入** — 註冊新帳號，或使用預設管理員帳號登入：
+
+   | 帳號 | 密碼 |
+   |------|------|
+   | `admin` | `admin123` |
+
+   > 🔐 **正式使用前請務必修改預設管理員密碼。**
+
+2. **輸入 Moodle 憑證** — 在下載頁面填入你的 Moodle 學號與密碼。
+3. **選擇平台** — 從清單選擇 Moodle 站台，或輸入自訂網址。
+4. **開始下載** — 點擊「開始下載」，進度會即時顯示。
+5. **管理檔案** — 於檔案管理頁面瀏覽、下載單檔，或將整個課程打包成 ZIP。
+
+## 🗂 專案結構
 
 ```
 moosaver/
-├── download/           # 主要下載功能應用
-├── users/             # 使用者管理應用
-├── moosaver/          # Django 專案設定
-├── templates/         # 前端模板
-├── requirements.txt   # Python 依賴
-├── Dockerfile        # Docker 配置
-└── manage.py         # Django 管理命令
-└── db.sqlite3        # Django Data Model DB (Generated)
+├── download/            # 下載功能應用（下載、進度回報、檔案管理）
+│   ├── moodle_dl_utils.py   # Moodle-DL 封裝與下載流程
+│   ├── views.py             # 下載 / 檔案管理 API 與頁面
+│   └── templates/           # 下載、檔案管理等前端模板
+├── users/               # 使用者管理應用（註冊、登入、管理後台）
+├── moosaver/            # Django 專案設定（settings、urls、wsgi/asgi）
+├── requirements.txt     # Python 依賴（已鎖定版本）
+├── Dockerfile           # Docker 映像檔建置設定
+├── entrypoint.sh        # 容器啟動腳本（遷移 + 建立 admin + 啟動）
+├── manage.py            # Django 管理指令
+└── db.sqlite3           # SQLite 資料庫（執行後自動產生）
 ```
 
-## 開源專案致謝
+## 🔒 安全性說明
 
-本專案使用了以下開源專案和函式庫：
+- 你輸入的 **Moodle 密碼不會被儲存**；系統僅用它向 Moodle 官方 API 換取存取權杖（token），權杖存放於你自己的資料卷中。
+- 本專案預設以 Django 開發模式（`DEBUG=True`）執行，**不適合直接對外公開部署**。若要架設於公網，請自行關閉 DEBUG、更換 `SECRET_KEY`、設定 `ALLOWED_HOSTS`，並置於反向代理之後。
+- 建議在信任的本機或內網環境使用。
 
-### 後端框架
-- [Django](https://github.com/django/django) - BSD-3-Clause License
-  - Python Web 框架
+## 🗺 Roadmap
 
-### 前端框架和元件
-- [Vue.js 3](https://github.com/vuejs/core) - MIT License
-  - 漸進式 JavaScript 框架
-- [Font Awesome](https://github.com/FortAwesome/Font-Awesome) - Font Awesome Free License
-  - 圖示字體庫
+- [ ] 提供多架構（arm64）Docker 映像檔
+- [ ] 排程 / 自動定期同步
+- [ ] 下載完成通知（Email / Telegram / Discord）
+- [ ] 更完善的下載選項 UI（免改程式碼即可調整）
 
-### 字體
-- [Noto Sans TC](https://fonts.google.com/noto/specimen/Noto+Sans+TC) - Open Font License
-  - Google Fonts 繁體中文字體
+歡迎在 [Issues](https://github.com/Ruxiu0409/moosaver/issues) 提出想法。
 
-### Moodle 下載核心
-- [Moodle-DL](https://github.com/C0D3D3V/Moodle-DL) - GPL-3.0 license
+## 🤝 貢獻
 
-## 授權條款
+歡迎任何形式的貢獻！
+
+1. Fork 本專案
+2. 建立特性分支：`git checkout -b feature/my-feature`
+3. 提交變更：`git commit -m "Add my feature"`
+4. 推送分支：`git push origin feature/my-feature`
+5. 開啟 Pull Request
+
+有問題或建議也歡迎直接建立 [Issue](https://github.com/Ruxiu0409/moosaver/issues)。
+
+## 🙏 開源致謝
+
+本專案站在以下優秀開源專案的肩膀上：
+
+| 專案 | 用途 | 授權 |
+|------|------|------|
+| [Moodle-DL](https://github.com/C0D3D3V/Moodle-DL) | Moodle 下載核心 | GPL-3.0 |
+| [Django](https://github.com/django/django) | Python Web 框架 | BSD-3-Clause |
+| [Vue.js 3](https://github.com/vuejs/core) | 前端框架 | MIT |
+| [Font Awesome](https://github.com/FortAwesome/Font-Awesome) | 圖示字體庫 | Font Awesome Free |
+| [Noto Sans TC](https://fonts.google.com/noto/specimen/Noto+Sans+TC) | 繁體中文字體 | SIL Open Font License |
+
+## 📄 授權條款
 
 本專案採用 [GNU General Public License v3.0](LICENSE) 授權。
 
-## 貢獻
+由於使用了以 GPL-3.0 授權的 Moodle-DL，本專案亦遵循 GPL-3.0。
 
-歡迎提交 Issue 和 Pull Request 來改善這個專案。
+---
 
-## 聯繫方式
-
-如有問題或建議，請建立 Issue 或聯繫專案維護者。
+<div align="center">
+若這個專案對你有幫助，歡迎點一顆 ⭐ Star 支持！
+</div>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="banner.svg" alt="MooSaver banner" width="100%">
+
 # 🐄 MooSaver
 
 **一鍵批次備份 Moodle 課程資源的自架下載工具**

--- a/banner.svg
+++ b/banner.svg
@@ -1,0 +1,98 @@
+<svg width="1280" height="420" viewBox="0 0 1280 420" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">MooSaver Moodle-style banner</title>
+  <desc id="desc">MooSaver banner with Moodle-inspired course cards, module rows, and course backup visual elements.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1280" y2="420" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFF7ED"/>
+      <stop offset="0.52" stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#EAF7F0"/>
+    </linearGradient>
+    <linearGradient id="orange" x1="152" y1="76" x2="1066" y2="349" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F98012"/>
+      <stop offset="1" stop-color="#FFB238"/>
+    </linearGradient>
+    <linearGradient id="green" x1="748" y1="248" x2="1000" y2="324" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1FA463"/>
+      <stop offset="1" stop-color="#22C55E"/>
+    </linearGradient>
+    <filter id="softShadow" x="107" y="39" width="1066" height="362" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="18"/>
+      <feGaussianBlur stdDeviation="26"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.2 0 0 0 0 0.11 0 0 0 0 0.03 0 0 0 0.16 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+    <pattern id="dots" width="42" height="42" patternUnits="userSpaceOnUse">
+      <circle cx="6" cy="6" r="2" fill="#F98012" fill-opacity="0.12"/>
+    </pattern>
+  </defs>
+
+  <rect width="1280" height="420" fill="url(#bg)"/>
+  <rect width="1280" height="420" fill="url(#dots)"/>
+  <path d="M0 318C113 286 222 298 334 324C454 352 558 369 686 333C815 297 937 257 1080 292C1149 309 1207 338 1280 321V420H0V318Z" fill="#FAD7A0" fill-opacity="0.45"/>
+  <path d="M0 352C166 318 282 347 410 364C551 383 691 355 823 318C956 281 1094 305 1280 363V420H0V352Z" fill="#BFE8CF" fill-opacity="0.65"/>
+
+  <g filter="url(#softShadow)">
+    <rect x="140" y="64" width="1000" height="284" rx="30" fill="#FFFFFF"/>
+    <rect x="140" y="64" width="1000" height="74" rx="30" fill="url(#orange)"/>
+    <path d="M140 109H1140V138H140V109Z" fill="url(#orange)"/>
+  </g>
+
+  <g transform="translate(180 88)">
+    <circle cx="24" cy="14" r="7" fill="#FFFFFF" fill-opacity="0.92"/>
+    <circle cx="49" cy="14" r="7" fill="#FFFFFF" fill-opacity="0.72"/>
+    <circle cx="74" cy="14" r="7" fill="#FFFFFF" fill-opacity="0.72"/>
+    <rect x="118" y="2" width="250" height="24" rx="12" fill="#FFFFFF" fill-opacity="0.28"/>
+    <rect x="856" y="0" width="64" height="28" rx="14" fill="#FFFFFF" fill-opacity="0.24"/>
+  </g>
+
+  <g transform="translate(196 166)">
+    <rect x="0" y="0" width="286" height="158" rx="20" fill="#FFF7ED" stroke="#FED7AA" stroke-width="2"/>
+    <rect x="24" y="24" width="88" height="74" rx="16" fill="#F98012"/>
+    <path d="M46 54L68 42L90 54L68 66L46 54Z" fill="#FFFFFF"/>
+    <path d="M55 60V75C55 81 60 86 68 86C76 86 81 81 81 75V60" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round"/>
+    <path d="M90 54V74" stroke="#FFFFFF" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="90" cy="79" r="5" fill="#FFFFFF"/>
+    <rect x="132" y="30" width="120" height="14" rx="7" fill="#9A3412" fill-opacity="0.92"/>
+    <rect x="132" y="61" width="96" height="12" rx="6" fill="#C2410C" fill-opacity="0.52"/>
+    <rect x="132" y="89" width="124" height="12" rx="6" fill="#C2410C" fill-opacity="0.32"/>
+    <rect x="24" y="124" width="82" height="10" rx="5" fill="#F98012" fill-opacity="0.48"/>
+    <rect x="120" y="124" width="74" height="10" rx="5" fill="#22C55E" fill-opacity="0.38"/>
+    <rect x="208" y="124" width="54" height="10" rx="5" fill="#0EA5E9" fill-opacity="0.35"/>
+  </g>
+
+  <g transform="translate(518 174)">
+    <text x="0" y="56" fill="#1F2937" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="60" font-weight="850" letter-spacing="0">MooSaver</text>
+    <text x="2" y="96" fill="#7C2D12" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="22" font-weight="750" letter-spacing="0">Moodle resources, backed up in one click</text>
+    <g transform="translate(2 128)">
+      <rect x="0" y="0" width="118" height="36" rx="18" fill="#FFF1E6"/>
+      <text x="20" y="24" fill="#C2410C" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="800" letter-spacing="0">Courses</text>
+      <rect x="132" y="0" width="128" height="36" rx="18" fill="#EAF7EF"/>
+      <text x="153" y="24" fill="#15803D" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="800" letter-spacing="0">Resources</text>
+      <rect x="274" y="0" width="110" height="36" rx="18" fill="#EEF6FF"/>
+      <text x="296" y="24" fill="#0369A1" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="15" font-weight="800" letter-spacing="0">Archive</text>
+    </g>
+  </g>
+
+  <g transform="translate(918 152)">
+    <rect x="0" y="0" width="194" height="176" rx="20" fill="#F8FAFC" stroke="#E2E8F0" stroke-width="2"/>
+    <rect x="18" y="18" width="154" height="28" rx="14" fill="#F98012" fill-opacity="0.16"/>
+    <circle cx="35" cy="32" r="7" fill="#F98012"/>
+    <rect x="51" y="26" width="92" height="12" rx="6" fill="#9A3412" fill-opacity="0.72"/>
+    <rect x="18" y="62" width="154" height="26" rx="13" fill="#FFFFFF" stroke="#E2E8F0"/>
+    <path d="M32 75H46" stroke="#F98012" stroke-width="5" stroke-linecap="round"/>
+    <path d="M60 75H135" stroke="#64748B" stroke-width="5" stroke-linecap="round"/>
+    <rect x="18" y="98" width="154" height="26" rx="13" fill="#FFFFFF" stroke="#E2E8F0"/>
+    <path d="M32 111H46" stroke="#22C55E" stroke-width="5" stroke-linecap="round"/>
+    <path d="M60 111H124" stroke="#64748B" stroke-width="5" stroke-linecap="round"/>
+    <rect x="18" y="134" width="90" height="10" rx="5" fill="#CBD5E1"/>
+    <rect x="18" y="154" width="118" height="8" rx="4" fill="#E2E8F0"/>
+    <g transform="translate(104 112)">
+      <circle cx="36" cy="36" r="31" fill="url(#green)"/>
+      <path d="M23 36L33 46L51 26" stroke="#FFFFFF" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+  </g>
+</svg>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 moodle-dl==2.3.13
-requests
-django-widget-tweaks
-django
+requests==2.34.2
+django-widget-tweaks==1.5.1
+django==6.0.7


### PR DESCRIPTION
## 概述

兩個獨立的改善，讓專案更容易上手與長期維護：

### 1. 鎖定依賴版本 (`4b2abb3`)

`requirements.txt` 中的 `requests`、`django-widget-tweaks`、`django` 原本未鎖定版本。時間一久，全新安裝可能拉到不相容的新版而導致無法啟動。

已鎖定為實測可正常運作的版本組合：

```
moodle-dl==2.3.13
requests==2.34.2
django-widget-tweaks==1.5.1
django==6.0.7
```

> 已用逢甲 iLearn 帳號實測：token 取得、課程檔案批次下載、各頁面皆正常運作。

### 2. 重寫 README (`9f5bacf`)

將 README 整理成更完整的開源專案文件：

- 加上 badges、可跳轉目錄
- 支援平台表、技術架構表
- 更清楚的 Docker / 本地開發快速開始步驟
- 新增設定說明、安全性說明、Roadmap、貢獻指南
- 文件中的版本資訊與程式碼對齊（Django 6.0、Python 3.12+）

## 測試

- `pip install -r requirements.txt` ✅
- `python manage.py migrate` ✅
- 實際下載課程資源（1500+ 檔案）✅
- 所有頁面回應正常 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)